### PR TITLE
Fix frontend-backend disconnection and add Supabase config check

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Sidebar from './components/Sidebar';
 import MainPanel from './components/MainPanel';
 import RightPanel from './components/RightPanel';
+import { isSupabaseConfigured } from './supabaseClient';
 import './App.css';
 
 function App() {
@@ -13,6 +14,17 @@ function App() {
   });
   const [artifacts, setArtifacts] = useState([]);
   const [isRightPanelVisible, setIsRightPanelVisible] = useState(false);
+
+  if (!isSupabaseConfigured) {
+    return (
+      <div className="app-container">
+        <div className="error-message">
+          <h1>Supabase not configured</h1>
+          <p>Please set the VITE_SUPABASE_URL and VITE_SUPABASE_API environment variables in your .env file.</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="app-container">

--- a/src/api/chat.js
+++ b/src/api/chat.js
@@ -1,7 +1,7 @@
-import { supabase } from '../supabaseClient';
+import { supabase, isSupabaseConfigured } from '../supabaseClient';
 
 export const getChats = async (userId) => {
-  if (!userId) return [];
+  if (!isSupabaseConfigured || !userId) return [];
   const { data, error } = await supabase
     .from('chats')
     .select('id, title, created_at')
@@ -15,6 +15,7 @@ export const getChats = async (userId) => {
 };
 
 export const createChat = async (userId, title) => {
+  if (!isSupabaseConfigured) return null;
   const { data, error } = await supabase
     .from('chats')
     .insert([{ user_id: userId, title }])
@@ -27,7 +28,7 @@ export const createChat = async (userId, title) => {
 };
 
 export const getMessages = async (chatId) => {
-  if (!chatId) return [];
+  if (!isSupabaseConfigured || !chatId) return [];
   const { data, error } = await supabase
     .from('messages')
     .select('role, content')
@@ -41,6 +42,7 @@ export const getMessages = async (chatId) => {
 };
 
 export const saveMessage = async (chatId, role, content) => {
+  if (!isSupabaseConfigured) return;
   const { error } = await supabase
     .from('messages')
     .insert([{ chat_id: chatId, role, content }]);
@@ -50,7 +52,7 @@ export const saveMessage = async (chatId, role, content) => {
 };
 
 export const deleteAllChats = async (userId) => {
-    if (!userId) return;
+    if (!isSupabaseConfigured || !userId) return;
     const { error } = await supabase
         .from('chats')
         .delete()
@@ -65,7 +67,7 @@ export const ingestFile = async (file) => {
   formData.append('file', file);
 
   try {
-    const response = await fetch('http://localhost:8000/ingest', {
+    const response = await fetch('/api/ingest', {
       method: 'POST',
       body: formData,
     });

--- a/src/components/MainPanel.jsx
+++ b/src/components/MainPanel.jsx
@@ -16,7 +16,7 @@ const MainPanel = ({ selectedChat, settings, setSettings, setArtifacts, setIsRig
   useEffect(() => {
     const fetchThinkingPhrases = async () => {
       try {
-        const response = await axios.get('http://localhost:8000/thinking');
+        const response = await axios.get('/api/thinking');
         if (response.data.phrases && response.data.phrases.length > 0) {
             setThinkingPhrases(response.data.phrases);
         }
@@ -55,7 +55,7 @@ const MainPanel = ({ selectedChat, settings, setSettings, setArtifacts, setIsRig
   const processArtifacts = async (aiResponseContent) => {
     const codeArtifacts = extractCode(aiResponseContent);
 
-    const figuresResponse = await axios.get('http://localhost:8000/figures');
+    const figuresResponse = await axios.get('/api/figures');
     const plotArtifacts = figuresResponse.data.figures.map(figJson => ({
       type: 'plot',
       content: JSON.parse(figJson),
@@ -82,7 +82,7 @@ const MainPanel = ({ selectedChat, settings, setSettings, setArtifacts, setIsRig
     setIsRightPanelVisible(false);
     setArtifacts([]);
 
-    const eventSource = new EventSource(`http://localhost:8000/chat/stream?user_input=${encodeURIComponent(input)}&model=${settings.model}&temperature=${settings.temperature}&verbosity=${settings.verbosity}`);
+    const eventSource = new EventSource(`/api/chat/stream?user_input=${encodeURIComponent(input)}&model=${settings.model}&temperature=${settings.temperature}&verbosity=${settings.verbosity}`);
 
     let aiResponse = { role: 'ai', content: '' };
     setMessages(prevMessages => [...prevMessages, aiResponse]);

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -3,8 +3,16 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_API;
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error("Supabase URL and API Key are required. Please check your .env file.");
+let supabase = null;
+let isSupabaseConfigured = false;
+
+if (supabaseUrl && supabaseAnonKey) {
+  try {
+    supabase = createClient(supabaseUrl, supabaseAnonKey);
+    isSupabaseConfigured = true;
+  } catch (error) {
+    console.error("Error initializing Supabase:", error);
+  }
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export { supabase, isSupabaseConfigured };

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,20 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+
+  return {
+    plugins: [react()],
+    server: {
+      proxy: {
+        '/api': {
+          target: env.VITE_BACKEND_URL || 'http://localhost:8000',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/api/, ''),
+        },
+      },
+    },
+  }
 })


### PR DESCRIPTION
This commit addresses the disconnection between the frontend and backend by:

1.  **Introducing a Vite proxy:** All backend API calls from the frontend are now routed through a proxy defined in `vite.config.js`. This removes hardcoded `localhost:8000` URLs from the frontend code, making the application more robust and configurable. The backend URL can now be set using the `VITE_BACKEND_URL` environment variable.

2.  **Adding a Supabase configuration check:** The application now gracefully handles the case where Supabase environment variables (`VITE_SUPABASE_URL` and `VITE_SUPABASE_API`) are not set. Instead of crashing, it displays an informative error message to you, guiding you to configure your `.env` file. API calls that depend on Supabase will now fail silently if it's not configured.